### PR TITLE
Improved error message when config not found

### DIFF
--- a/badlist/update_server.py
+++ b/badlist/update_server.py
@@ -187,7 +187,10 @@ class BadlistUpdateServer(ServiceUpdater):
             [prepare_item(bl_item) for bl_item in badlist_items]
             blocklist_batch.extend(badlist_items)
 
-        source_cfg = self._service.config["updater"][source_name]
+        try:
+            source_cfg = self._service.config["updater"][source_name]
+        except KeyError as exc:
+            raise ValueError(f"Source '{source_name}' not found in the service configuration") from exc
 
         if source_cfg["type"] == "blocklist":
             # This source is meant to contribute to the blocklist


### PR DESCRIPTION
Badlist requires configuring sources in two places, on the source list and in the service configuration. If the name of the source isn't found in the service config, the default KeyError is handled in the way that both Update sources and logs shows the source name as the error. This change handles the KeyError and re-raise as ValueError with the message pointing user to the missing configuration. It's especially important for users trying to add their own sources, not included in the default config.